### PR TITLE
Fix Doctrine DBAL 4 compatibility in DoctrineSchemaListener

### DIFF
--- a/src/EventListener/DoctrineSchemaListener.php
+++ b/src/EventListener/DoctrineSchemaListener.php
@@ -61,10 +61,10 @@ class DoctrineSchemaListener
                         'fixed' => $origin_type == 'char',
                         'default' => $default,
                         'notnull' => $notnull,
-                        'scale' => null,
-                        'precision' => null,
+                        'scale' => 0,
+                        'precision' => 10,
                         'autoincrement' => $autoincrement,
-                        'comment' => null,
+                        'comment' => '',
                     ];
 
                     $objTable->addColumn($strField, $type, $arrOptions);


### PR DESCRIPTION
## Problem

When using Doctrine DBAL 4 (e.g. via Contao 5.7), the `DoctrineSchemaListener` throws `TypeError` exceptions during cache warmup:

```
Doctrine\DBAL\Schema\Column::setScale(): Argument #1 ($scale) must be of type int, null given
Doctrine\DBAL\Schema\Column::setComment(): Argument #1 ($comment) must be of type string, null given
```

In DBAL 4, the `setScale()`, `setPrecision()` and `setComment()` methods no longer accept `null` values.

## Fix

Replace `null` with proper default values in the column options array:
- `'scale' => 0` (was `null`)
- `'precision' => 10` (was `null`)
- `'comment' => ''` (was `null`)